### PR TITLE
Potential fix for code scanning alert no. 4: Empty except

### DIFF
--- a/upvote.py
+++ b/upvote.py
@@ -101,8 +101,8 @@ def upvote_question(slido_id, slido_qid, load_delay, max_votes, queue):
                         question_found = True
                         logger.info("Found")
                         break
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Exception occurred while searching for question element: {e}")
 
                 logger.info("Not found, scrolling...")
                 page.evaluate("window.scrollTo(0, document.body.scrollHeight);")


### PR DESCRIPTION
Potential fix for [https://github.com/micxer/slido-upvoter/security/code-scanning/4](https://github.com/micxer/slido-upvoter/security/code-scanning/4)

The best way to fix this problem is to *not* ignore exceptions silently. At a minimum, exceptions should be logged, so an operator or developer can trace what caused delays or failures in scanning for a question element. This typically means logging the exception message and potentially the stack trace within the `except` block. If only certain exceptions are expected (such as DOM-related or timeouts), the handler should preferably only catch those, rather than all exceptions. However, since the current block catches `Exception` and it's unclear from the snippet which exceptions are expected, a minimal fix here is to log the exception using the provided `logger` instance. The relevant fix is to replace the `pass` statement on line 105 with a logging statement.

Only the code at lines 104–105 in `upvote.py` needs changing—no new imports or definitions are necessary, as the logger is already initialized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
